### PR TITLE
Make the stored data reproducible between builds

### DIFF
--- a/lib/Perl/APIReference.pm
+++ b/lib/Perl/APIReference.pm
@@ -141,6 +141,7 @@ sub _dump_as_class {
   require Sereal::Encoder;
   my $data = $self->{'index'};
   my $dump = Sereal::Encoder->new({
+    canonical      => 1,
     compress       => Sereal::Encoder::SRL_ZLIB(),
     compress_level => 9,
     dedupe_strings => 1,


### PR DESCRIPTION
The 'canonical' option makes Sereal::Encoder produce serialized data
structures that don't vary between builds.  This makes the build
result reproducible.

Bug-Debian: https://bugs.debian.org/807111
